### PR TITLE
Style improvements for suggestions and proposals page.

### DIFF
--- a/front-end/src/I18N/en.js
+++ b/front-end/src/I18N/en.js
@@ -230,6 +230,7 @@ const en = {
   'suggestion.befirst': 'Be the first one to create a suggestion',
   'suggestion.subject': 'Subject',
   'suggestion.title': 'Suggestions',
+  'suggestion.listTitle': 'All suggestions',
   'suggestion.add': 'Add a Suggestion',
   'suggestion.sort': 'Sort by',
   'suggestion.likes': 'Likes',

--- a/front-end/src/I18N/zh.js
+++ b/front-end/src/I18N/zh.js
@@ -230,6 +230,7 @@ const zh = {
   'suggestion.befirst': '成为第一个提出建议的人',
   'suggestion.subject': '主题',
   'suggestion.title': '建议',
+  'suggestion.listTitle': '所有建议',
   'suggestion.add': '添加一项建议',
   'suggestion.sort': '排序方式',
   'suggestion.likes': '点赞量',

--- a/front-end/src/module/page/CVote/list/Component.js
+++ b/front-end/src/module/page/CVote/list/Component.js
@@ -100,15 +100,17 @@ export default class extends BaseComponent {
     )
     return (
       <div className="p-cvote-list">
-        <h3 className="title komu-a cr-title-with-icon">
-          {I18N.get('council.voting.proposalList')}
-        </h3>
         <div className="d_box">
           <Row className="header">
-            <Col span={12}>
+            <Col span={8}>
+              <h3 style={{ textAlign: 'left', paddingBottom: 0 }} className="komu-a cr-title-with-icon">
+                {I18N.get('council.voting.proposalList')}
+              </h3>
+            </Col>
+            <Col span={8}>
               {statusIndicator}
             </Col>
-            <Col span={12}>
+            <Col span={8}>
               {createBtn}
             </Col>
           </Row>

--- a/front-end/src/module/page/CVote/list/Component.js
+++ b/front-end/src/module/page/CVote/list/Component.js
@@ -99,18 +99,16 @@ export default class extends BaseComponent {
       </Button>
     )
     return (
-      <div className="p-cvote-list ebp-wrap">
+      <div className="p-cvote-list">
+        <h3 className="title komu-a cr-title-with-icon">
+          {I18N.get('council.voting.proposalList')}
+        </h3>
         <div className="d_box">
           <Row className="header">
-            <Col span={8}>
-              <h3 style={{ textAlign: 'left', paddingBottom: 0 }} className="komu-a cr-title-with-icon">
-                {I18N.get('council.voting.proposalList')}
-              </h3>
-            </Col>
-            <Col span={8}>
+            <Col span={12}>
               {statusIndicator}
             </Col>
-            <Col span={8}>
+            <Col span={12}>
               {createBtn}
             </Col>
           </Row>

--- a/front-end/src/module/page/CVote/list/style.scss
+++ b/front-end/src/module/page/CVote/list/style.scss
@@ -3,28 +3,35 @@
 
 .p-cvote-list{
   text-align: center;
-
+  margin: 50px 108px 80px 108px;
+  
+  .title {
+    font-size: 96px;
+    text-align: left;
+  }
   .d_box {
-    padding: 0 50px 80px;
-    width: 80vw;
-    margin: 80px auto 0;
+    // padding: 0 50px 80px;
+    // width: 80vw;
+    // margin: 80px auto 0;
     background: #ffffff;
   }
   .header {
     display: flex;
     align-items: center;
+    margin-bottom: 10px;
   }
   .vote-status-list {
     display: flex;
     align-items: center;
-    font-size: 10px;
+    font-size: 14px;
   }
   .vote-status-item {
     flex: 0 0 10px;
     height: 10px;
     box-sizing: border-box;
-    margin-right: 1px;
-    margin-left: 5px;
+    margin-right: 2px;
+    margin-left: 10px;
+
     &.undecided {
       background: #EFEFEF;
     }
@@ -32,6 +39,7 @@
       background: #CED6E3;
     }
     &.yes {
+      margin-left: 0;
       background: $cr_primary_highlight;
     }
     &.no {

--- a/front-end/src/module/page/suggestion/list/Component.js
+++ b/front-end/src/module/page/suggestion/list/Component.js
@@ -90,14 +90,14 @@ export default class extends StandardPage {
           </MediaQuery>
           <MediaQuery minWidth={LG_WIDTH+1}>
             <Row gutter={24}>
-              <Col span={15}>{actionsNode}</Col>
-              <Col span={9}>{addButtonNode}</Col>
+              <Col span={16}>{actionsNode}</Col>
+              <Col span={8}>{addButtonNode}</Col>
             </Row>
             <Row gutter={24}>
-              <Col span={15}>
+              <Col span={16}>
                 {listNode}
               </Col>
-              <Col span={9}>{mySuggestionNode}</Col>
+              <Col span={8}>{mySuggestionNode}</Col>
             </Row>
           </MediaQuery>
           {createForm}
@@ -221,7 +221,12 @@ export default class extends StandardPage {
 
     return (
       <div>
-        <div className="list-container">{result}</div>
+        <div className="list-container">
+          <div>
+            <h2 className="title komu-a">{I18N.get('suggestion.listTitle').toUpperCase()}</h2>
+          </div>
+          {result}
+        </div>
         {paginationNode}
       </div>
     )

--- a/front-end/src/module/page/suggestion/list/style.scss
+++ b/front-end/src/module/page/suggestion/list/style.scss
@@ -2,9 +2,8 @@
 @import "@/style/color";
 
 .p_SuggestionList {
-  margin-left: 108px;
-  margin-top: 50px;
-  margin-bottom: 80px;
+  margin: 50px 108px 80px 108px;
+
   .title {
     font-size: 96px;
   }
@@ -31,6 +30,9 @@
     &:not(:last-child) {
       border-bottom: 1px solid #E5E5E5;
     }
+  }
+  .list-container .title {
+    font-size: 30px;
   }
   .title-link {
     font-size: 20px;

--- a/front-end/src/module/page/suggestion/my_list/style.scss
+++ b/front-end/src/module/page/suggestion/my_list/style.scss
@@ -2,8 +2,6 @@
 @import "@/style/color";
 
 .p_MySuggestionList {
-  background: $bg_lighter_gray;
-  padding: 40px 30px;
   .cr-mysuggestion-header .title {
     font-size: 30px;
   }

--- a/front-end/src/module/page/suggestion/my_list/style.scss
+++ b/front-end/src/module/page/suggestion/my_list/style.scss
@@ -2,6 +2,8 @@
 @import "@/style/color";
 
 .p_MySuggestionList {
+  background: $bg_lighter_gray;
+  padding: 40px 30px;
   .cr-mysuggestion-header .title {
     font-size: 30px;
   }


### PR DESCRIPTION
The design was bugging me for quite some time (since new release :laughing: ), so I wanted to make it nicer.
I want to bring more consistency for Suggestions and Proposals page.

Changes for both pages:
- Adjusted margin, padding and alignment for various elements so they align properly and look better.
- Adjusted font size for title, subtitle and table legend
- Added additional title "All suggestions" for suggestion list, so it properly align with "My suggestions". Looks much nicer IMO.
- Removed background for my suggestions
- Proposals table is now wider

It would be nice that we add an explanation/description text for Proposals page, just like we have right now on Suggestions page.

That's it.