### PR TITLE
🔨 Add options to access server via IP on development

### DIFF
--- a/front-end/webpack/webpack.dev.js
+++ b/front-end/webpack/webpack.dev.js
@@ -71,6 +71,7 @@ module.exports = merge(common, {
         contentBase: 'dev_dist',
         port: 3001,
         hot: true,
+        host: '0.0.0.0',
         /*
         headers: {
             'X-Frame-Options': 'allow-from https://www.facebook.com/'


### PR DESCRIPTION
Add option for testing on real device (mobile / tablet / desktop) and connect to the node server via IP